### PR TITLE
[textConnect] Feature update to resolve issue with delimiters appending to empty fields

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.eslintignore
+.eslintrc.js
+package.json

--- a/examples/textConnect/config_js/config.js
+++ b/examples/textConnect/config_js/config.js
@@ -108,7 +108,7 @@ jQuery.noConflict();
                         }
                         break;
 
-                    default :
+                    default:
                         break;
                 }
             }

--- a/examples/textConnect/config_js/config.js
+++ b/examples/textConnect/config_js/config.js
@@ -4,9 +4,9 @@
  *
  * Licensed under the MIT License
  */
-'use strict';
 jQuery.noConflict();
 (function($, PLUGIN_ID) {
+    'use strict';
 
     // プラグインIDの設定
     var CONF = kintone.plugin.app.getConfig(PLUGIN_ID);

--- a/examples/textConnect/config_js/config.js
+++ b/examples/textConnect/config_js/config.js
@@ -4,9 +4,9 @@
  *
  * Licensed under the MIT License
  */
+'use strict';
 jQuery.noConflict();
 (function($, PLUGIN_ID) {
-    'use strict';
 
     // プラグインIDの設定
     var CONF = kintone.plugin.app.getConfig(PLUGIN_ID);

--- a/examples/textConnect/desktops/desktop.js
+++ b/examples/textConnect/desktops/desktop.js
@@ -4,9 +4,8 @@
  *
  * Licensed under the MIT License
  */
-
-'use strict';
 (function(PLUGIN_ID) {
+    'use strict';
     // Load setting values such as target fields to connect, resolve fields, and delimiters.
     var CONF = kintone.plugin.app.getConfig(PLUGIN_ID);
 
@@ -54,7 +53,7 @@
 
             // そのほかのすべてのフィールドタイプ
             // All other field types
-            default :
+            default:
                 tex_changes = tex['value'];
                 break;
         }

--- a/examples/textConnect/desktops/desktop.js
+++ b/examples/textConnect/desktops/desktop.js
@@ -4,12 +4,12 @@
  *
  * Licensed under the MIT License
  */
-(function(PLUGIN_ID) {
-    'use strict';
 
+'use strict';
+(function(PLUGIN_ID) {
     // Load setting values such as target fields to connect, resolve fields, and delimiters.
     var CONF = kintone.plugin.app.getConfig(PLUGIN_ID);
-    
+
     // 設定値読み込み
     if (!CONF) {
         return false;
@@ -99,9 +99,9 @@
 
 
     function connectField(record) {
-        
+
         // 各結合項目の処理
-        // Every iteration, one resolve field is calculated based on it's delimiter and selection fields.
+        // Every iteration, one resolve field is calculated based on its delimiter and selection fields.
         for (var i = 1; i < 4; i++) {
             var cdcopyfield = CONF['copyfield' + i];
             var cdbetween = CONF['between' + i];
@@ -110,9 +110,7 @@
 
             // Filter rawTextArray to only include non empty strings
             var filteredTextArray = rawTextArray.filter(function(text) {
-                if (text != '')
-                    return true;
-                return false;
+                return text !== "";
             });
 
             // Special cases for delimiters of '&nbsp;' and '&emsp;'

--- a/examples/textConnect/desktops/desktop.js
+++ b/examples/textConnect/desktops/desktop.js
@@ -7,7 +7,9 @@
 (function(PLUGIN_ID) {
     'use strict';
 
+    // Load setting values such as target fields to connect, resolve fields, and delimiters.
     var CONF = kintone.plugin.app.getConfig(PLUGIN_ID);
+    
     // 設定値読み込み
     if (!CONF) {
         return false;
@@ -24,6 +26,7 @@
 
     function checkTexValue(tex) {
         var tex_changes = '';
+
         // ユーザー選択、組織選択、グループ選択でnameのみを取得する
         switch (tex['type']) {
             case 'USER_SELECT':
@@ -35,6 +38,7 @@
                 break;
 
             // 日時のうち、日付だけをトリムする
+            // Trim only the date of the date / time
             case 'DATETIME':
                 if (tex.value !== undefined) {
                     tex_changes = (tex['value']).substr(0, 10);
@@ -42,12 +46,14 @@
                 break;
 
             // 複数の値の場合は配列の0のみを反映する
+            // In case of multiple values, only 0 of the array is reflected
             case 'CHECK_BOX':
             case 'MULTI_SELECT':
                 tex_changes = tex['value'][0];
                 break;
 
             // そのほかのすべてのフィールドタイプ
+            // All other field types
             default :
                 tex_changes = tex['value'];
                 break;
@@ -56,11 +62,16 @@
     }
 
     // 空のフィールドを探す
+    // Calculate joinedText field given selectionArray and record
     function fieldValues(record, selectionArry) {
         var fieldarray = [];
+
+        // For all selection fields for the current group of target fields
         for (var j = 0; j < 5; j++) {
             if (selectionArry[j] !== '') {
                 var tex = record[String(selectionArry[j])];
+
+                // If text exists then add it to the fieldarray, other wise add empty string.
                 if (tex.value !== undefined) {
                     fieldarray.push(checkTexValue(tex));
                 } else {
@@ -73,7 +84,9 @@
     }
 
     function createSelectionArry() {
+
         // 行毎にselectionの配列を作成
+        // Create selection array for each row
         var selectionArry = [];
         selectionArry[0] = [];
         selectionArry[1] = [];
@@ -86,19 +99,32 @@
 
 
     function connectField(record) {
+        
         // 各結合項目の処理
+        // Every iteration, one resolve field is calculated based on it's delimiter and selection fields.
         for (var i = 1; i < 4; i++) {
             var cdcopyfield = CONF['copyfield' + i];
             var cdbetween = CONF['between' + i];
             var selectionArry = createSelectionArry();
-            var joinText = fieldValues(record, selectionArry[i - 1]);
+            var rawTextArray = fieldValues(record, selectionArry[i - 1]); // array of text field values
+
+            // Filter rawTextArray to only include non empty strings
+            var filteredTextArray = rawTextArray.filter(function(text) {
+                if (text != '')
+                    return true;
+                return false;
+            });
+
+            // Special cases for delimiters of '&nbsp;' and '&emsp;'
             if (cdbetween === '&nbsp;') {
                 cdbetween = '\u0020';
             } else if (cdbetween === '&emsp;') {
                 cdbetween = '\u3000';
             }
-            if (joinText.length > 0) {
-                record[String(cdcopyfield)]['value'] = String(joinText.join(cdbetween));
+
+            // Input back into resolve field in the record
+            if (filteredTextArray.length > 0) {
+                record[String(cdcopyfield)]['value'] = String(filteredTextArray.join(cdbetween));
             }
         }
     }
@@ -123,12 +149,14 @@
     }
 
     // 一覧作成編集画面
-    var events1 = ['app.record.edit.show',
+    var events1 = [
+        'app.record.edit.show',
         'app.record.create.show',
         'app.record.index.edit.show'
     ];
 
     // 結合フィールドを入力不可にする
+    // Disable the resolve field (gray out)
     kintone.events.on(events1, function(event) {
         var record = event['record'];
         for (var i = 1; i < 4; i++) {


### PR DESCRIPTION
### Changes made to TextConnect Plugin
- When TextConnect is asked to combine an empty field, it does not add an additional delimiter to the resolved field.

**example:** 

**Fields user wants to combine:**
First Name:[Shashank] Middle Name:[] Last Name:[Guduru]

**User selected delimiter:** ","

**What system does now:** 
Resolved Field: [Shashank,Guduru]

**What System did previously:**
Resolve Field: [Shashank,,Guduru] 

**_The extra comma problem is solved._**
